### PR TITLE
add awaitable once util

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -3,3 +3,4 @@ import 'reflect-metadata';
 export * from './constants';
 export * from './decorators';
 export * from './interfaces';
+export * from './utils';

--- a/packages/common/utils/events.util.ts
+++ b/packages/common/utils/events.util.ts
@@ -1,0 +1,39 @@
+import { EventEmitter } from 'events';
+
+/**
+ * Promisify event to await
+ * @param emitter
+ * @param name
+ */
+function once(emitter: EventEmitter, name) {
+  return new Promise((resolve, reject) => {
+    const eventListener = (...args) => {
+      if (errorListener !== undefined) {
+        emitter.removeListener('error', errorListener);
+      }
+      resolve(args);
+    };
+    let errorListener;
+
+    // Adding an error listener is not optional because
+    // if an error is thrown on an event emitter we cannot
+    // guarantee that the actual event we are waiting will
+    // be fired. The result could be a silent way to create
+    // memory or file descriptor leaks, which is something
+    // we should avoid.
+    if (name !== 'error') {
+      errorListener = (err) => {
+        emitter.removeListener(name, eventListener);
+        reject(err);
+      };
+
+      emitter.once('error', errorListener);
+    }
+
+    emitter.once(name, eventListener);
+  });
+}
+
+export {
+  once,
+};

--- a/packages/common/utils/index.ts
+++ b/packages/common/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './events.util';

--- a/packages/core/engine/kites-factory.spec.ts
+++ b/packages/core/engine/kites-factory.spec.ts
@@ -1,8 +1,9 @@
+import { once } from '@kites/common';
 import { expect } from 'chai';
 import { engine, KITES_INSTANCE } from './kites-factory';
 import { KitesInstance } from './kites-instance';
 
-describe('kites init', () => {
+describe('kites factory', () => {
   it('should init a new kites instance without options!', async () => {
     const app = await engine().init();
     app.logger.info('A new kites started!');
@@ -13,5 +14,18 @@ describe('kites init', () => {
       const instance = kites.container.inject(KITES_INSTANCE);
       expect(instance).instanceOf(KitesInstance);
     }).init();
+  });
+
+  it('should wait an event', (done) => {
+    engine().use(async (kites: KitesInstance) => {
+      try {
+        const v = await once(kites, 'ready');
+        expect(v).to.be.an('array', 'once event as a promise return an array!');
+        expect(v[0]).instanceOf(KitesInstance);
+        done();
+      } catch (error) {
+        done(error);
+      }
+    }).init().then(() => true).catch(done);
   });
 });


### PR DESCRIPTION
Fixes #30  

Example:

```ts
const v = await once(kites, 'ready');
expect(v).to.be.an('array', 'once event as a promise return an array!');
expect(v[0]).instanceOf(KitesInstance);
```